### PR TITLE
Add link to repl for each card

### DIFF
--- a/src/container/Card.svelte
+++ b/src/container/Card.svelte
@@ -1,11 +1,18 @@
 <script>
   export let title = ''
+  export let repl = ''
 </script>
 
 <section class="card">
   <header>
     <h2>{title}</h2>
-    <span class="circles" />
+    <div class="circles">
+      <a href={repl} class="circle red" title="código no REPL" target="_blank"
+        ><span /></a
+      >
+      <span class="circle yellow" />
+      <span class="circle green" />
+    </div>
   </header>
   <div>
     <slot>Content</slot>
@@ -35,15 +42,30 @@
   }
 
   header > .circles {
-    display: block;
+    height: var(--m18);
+  }
+
+  .circle {
+    display: inline-block;
     width: var(--m18);
     height: var(--m18);
     border-radius: 50%;
     background-color: var(--red-color);
     border: 1px solid #fff;
-    box-shadow: 25px 0 0 0 var(--yellow-color), 50px 0 0 0 var(--green-color);
-    margin-right: 50px;
-    margin-left: 20px;
+    margin: 0 0 0 5px;
+    content: '\f30c';
+    text-decoration: none;
+  }
+  .red {
+    background-color: var(--red-color);
+  }
+
+  .yellow {
+    background-color: var(--yellow-color);
+  }
+
+  .green {
+    background-color: var(--green-color);
   }
 
   .card > div {

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -1,6 +1,7 @@
 export const cheatSheet = [
   {
-    title: "Svelte Component",
+    title: 'Svelte Component',
+    repl: 'https://svelte.dev/repl/6a5416148c4b410b8ee0325eef54b107',
     content: `<!-- Widget.svelte -->
 <script>
   export let textValue
@@ -19,11 +20,12 @@ export const cheatSheet = [
   const title = 'App'
 </script>
 <header>{title}</header>
-<Widget textValue="I'm a svelte component" />
-`
+<Widget textValue="I'm a Svelte component" />
+`,
   },
   {
-    title: "Expressions",
+    title: 'Expressions',
+    repl: 'https://svelte.dev/repl/27bd55a7357046f2911923069dee9d86',
     content: `<script>
   let isShowing = true
   let cat = 'cat'
@@ -31,21 +33,21 @@ export const cheatSheet = [
   let email = 'professionalkiller@gmail.com'
 </script>
 <p>2 + 2 = {2 + 2}</p>
-   
+
 <p on:click={() => isShowing = !isShowing}>
-  {isShowing 
-    ? 'NOW YOU SEE ME 👀' 
+  {isShowing
+    ? 'NOW YOU SEE ME 👀'
     : 'NOW YOU DON\`T SEE ME 🙈'}
 </p>
 <p>My e-mail is {email}</p>
 <p>{user.name}</p>
 <p>{cat + \`s\`}</p>
-<p>{\`name \${user.name}\`}</p>`
-
+<p>{\`name \${user.name}\`}</p>`,
   },
   {
-    title: "Simple Bind",
-    content: `//MyLink.svelte
+    title: 'Simple Bind',
+    repl: 'https://svelte.dev/repl/505dfd64708844c7b28ead4834059d69',
+    content: `<!-- MyLink.svelte -->
 <script>
     export let href = ''
     export let title = ''
@@ -54,23 +56,28 @@ export const cheatSheet = [
 <a href={href} style={\`color: \${color}\`} >
   {title}
 </a>
-// Shorthand
+
+<!-- Shorthand
 <a {href} style={\`color: \${color}\`} >
   {title}
-</a>
+</a> -->
+
+<!-- App.svelte -->
 <script>
   import MyLink from "./components/MyLink";
   let link = {
     href: "http://www.mysite.com",
     title: "My Site",
+    repl: "#",
     color: "#ff3300"
   };
 </script>
 <MyLink {...link} />
-`
+`,
   },
   {
-    title: "Two Way Bind",
+    title: 'Two Way Bind',
+    repl: 'https://svelte.dev/repl/63c1cc2e6ab24d33ae531d6acdabc14e',
     content: `<MyInput bind:value={value} />
 // Shorthand
 <MyInput bind:value />
@@ -79,21 +86,21 @@ export const cheatSheet = [
   <option value="Beans">Beans</option>
   <option value="Cheese">Cheese</option>
 </select>
-<input 
-  type="radio" 
-  bind:group={tortilla} 
+<input
+  type="radio"
+  bind:group={tortilla}
   value="Plain" />
 <input
-  type="radio" 
-  bind:group={tortilla} 
+  type="radio"
+  bind:group={tortilla}
   value="Whole wheat" />
-<input 
-  type="checkbox" 
-  bind:group={fillings} 
+<input
+  type="checkbox"
+  bind:group={fillings}
   value="Rice" />
-<input 
-  type="checkbox" 
-  bind:group={fillings} 
+<input
+  type="checkbox"
+  bind:group={fillings}
   value="Beans" />
 // Element Binding
 <script>
@@ -103,10 +110,11 @@ export const cheatSheet = [
   Click
 </button>
 <div bind:this={myDiv}/>
-`
+`,
   },
   {
     title: 'Use action',
+    repl: '#',
     content: `<script>
   function myFunction(node) {
     // the node has been mounted in the DOM
@@ -118,10 +126,11 @@ export const cheatSheet = [
   }
 </script>
 <div use:myFunction></div>
-    `
+    `,
   },
   {
-    title: "Conditional Render",
+    title: 'Conditional Render',
+    repl: '#',
     content: `{#if condition}
   <p>Condition is true</p>
 {:else if otherCondition}
@@ -133,10 +142,11 @@ export const cheatSheet = [
 {#key value}
 	<div transition:fade>{value}</div>
 {/key}
-`
+`,
   },
   {
-    title: "Await Template",
+    title: 'Await Template',
+    repl: '#',
     content: `{#await promise}
   <p>waiting for the promise to resolve...</p>
 {:then value}
@@ -144,21 +154,21 @@ export const cheatSheet = [
 {:catch error}
   <p>Something went wrong: {error.message}</p>
 {/await}
-`
-
+`,
   },
   {
-    title: "Render HTML",
+    title: 'Render HTML',
+    repl: '#',
     content: `<scrit>
   const myHtml = '<span><strong>My text:</strong> text</span>'
 </scrit>
 {@html '<div>Content</div>'}
 {@html myHtml}
-`
-
+`,
   },
   {
-    title: "Handle Events",
+    title: 'Handle Events',
+    repl: '#',
     content: `<button on:click={handleClick}>
   Press me
 </button>
@@ -171,10 +181,11 @@ export const cheatSheet = [
 <button on:submit|preventDefault={handleClick}>
   Press me
 </button>
-`
+`,
   },
   {
-    title: "Forwarding Event",
+    title: 'Forwarding Event',
+    repl: '#',
     content: `// Widget.svelte
 <script>
   import { createEventDispatcher } from "svelte";
@@ -186,15 +197,15 @@ export const cheatSheet = [
 <script>
 import Widget from '.Widget.svelte'
 </script>
-<Widget 
-  on:click={() => alert('I was clicked')} 
+<Widget
+  on:click={() => alert('I was clicked')}
   on:message={e => alert(e.detail.text)}>
-`
+`,
   },
   {
-    title: "Rendering List",
-    content:
-      `<ul>
+    title: 'Rendering List',
+    repl: '#',
+    content: `<ul>
   {#each items as item}
   <li>{item.name} x {item.qty}</li>
   {:else}
@@ -213,13 +224,12 @@ import Widget from '.Widget.svelte'
     {index + 1}: {item.name} x {item.qty}
   </li>
 {/each}
-`
-
+`,
   },
   {
-    title: "Using Slot",
-    content:
-      `<!-- Widget.svelte -->
+    title: 'Using Slot',
+    repl: '#',
+    content: `<!-- Widget.svelte -->
 <div>
   <slot>Default content</slot>
 </div>
@@ -228,13 +238,12 @@ import Widget from '.Widget.svelte'
 <Widget>
   <p>I   changed the default content</p>
 </Widget>
-`
-
+`,
   },
   {
-    title: "Multiple Slot",
-    content:
-      `<!-- Widget.svelte -->
+    title: 'Multiple Slot',
+    repl: '#',
+    content: `<!-- Widget.svelte -->
 <div>
   <slot name="header">
     No header was provided
@@ -265,11 +274,11 @@ import Widget from '.Widget.svelte'
     {item.text}
   </div>
 </FancyList>
-`
-
+`,
   },
   {
-    title: "Class Binding",
+    title: 'Class Binding',
+    repl: '#',
     content: `<script>
    export let type = 'normal'
    export let active = true
@@ -282,13 +291,12 @@ import Widget from '.Widget.svelte'
 </div>
 // Match class
 <div class:active>...</div>
-`
-
+`,
   },
   {
-    title: "Lifecycle",
-    content:
-      `
+    title: 'Lifecycle',
+    repl: '#',
+    content: `
 <script>
 import onMount from 'svelte'
 onMount(() => {
@@ -302,32 +310,31 @@ onMount(() => {
   beforeUpdate(() => {}),
   afterUpdate(() => {}),
   onDestroy(() => {})
-]`
-
+]`,
   },
   {
-    title: "Animations",
-    content:
-      `<script>
+    title: 'Animations',
+    repl: '#',
+    content: `<script>
   import { flip } from "svelte/animate";
   import { quintOut } from "svelte/easing";
   let list = [1, 2, 3];
 </script>
 {#each list as n (n)}
-  <div animate:flip={{ 
-    delay: 250, 
-    duration: 250, 
+  <div animate:flip={{
+    delay: 250,
+    duration: 250,
     easing: quintOut
   }}>
     {n}
   </div>
 {/each}
-`
+`,
   },
   {
-    title: "Transitions",
-    content:
-`<script>
+    title: 'Transitions',
+    repl: '#',
+    content: `<script>
   import { fade } from "svelte/transition";
   export let condition;
 </script>
@@ -338,12 +345,12 @@ onMount(() => {
 {/if}
 // Other transitions
 [Blur, Scale, Fly, Draw, Slide]
-`
+`,
   },
   {
-    title: "Reactive Expressions",
-    content:
-`<script>
+    title: 'Reactive Expressions',
+    repl: '#',
+    content: `<script>
   let num = 0
   $: squared = num * num
   $: cubed = squared * num
@@ -353,12 +360,12 @@ onMount(() => {
 </button>
 <p>{squared}</p>
 <p>{cubed}</p>
-`
+`,
   },
   {
-    title: "Reactive Statement",
-    content:
-`<script>
+    title: 'Reactive Statement',
+    repl: '#',
+    content: `<script>
   $: if (count >= 10) {
     alert('count is dangerously high!')
     count = 9
@@ -387,6 +394,6 @@ onMount(() => {
     bar = await Promise.resolve(foo%2)
   })()
 </script>
-`
+`,
   },
 ]

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -114,7 +114,7 @@ export const cheatSheet = [
   },
   {
     title: 'Use action',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/6262d071414f42e98cdeed1f3c78d93e',
     content: `<script>
   function myFunction(node) {
     // the node has been mounted in the DOM
@@ -130,7 +130,7 @@ export const cheatSheet = [
   },
   {
     title: 'Conditional Render',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/b023c56cdf0d42819fe7ccc38ea75c41',
     content: `{#if condition}
   <p>Condition is true</p>
 {:else if otherCondition}
@@ -146,7 +146,7 @@ export const cheatSheet = [
   },
   {
     title: 'Await Template',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/22a36f1affba4334807a133d985ce6ef',
     content: `{#await promise}
   <p>waiting for the promise to resolve...</p>
 {:then value}
@@ -158,17 +158,18 @@ export const cheatSheet = [
   },
   {
     title: 'Render HTML',
-    repl: '#',
-    content: `<scrit>
+    repl: 'https://svelte.dev/repl/44896bb6272d48b2a0a5909678b07cc9',
+    content: `<script>
   const myHtml = '<span><strong>My text:</strong> text</span>'
-</scrit>
+</script>
+
 {@html '<div>Content</div>'}
 {@html myHtml}
 `,
   },
   {
     title: 'Handle Events',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/10cfb455b7b84514b35913aabee8b5c3',
     content: `<button on:click={handleClick}>
   Press me
 </button>
@@ -185,26 +186,28 @@ export const cheatSheet = [
   },
   {
     title: 'Forwarding Event',
-    repl: '#',
-    content: `// Widget.svelte
+    repl: 'https://svelte.dev/repl/f1e3b92d7a3c466bb614aa8f49cde3b1',
+    content: `<!-- Widget.svelte -->
 <script>
   import { createEventDispatcher } from "svelte";
   const dispatch = createEventDispatcher();
 </script>
-<button on:click={() => dispatch('message', { text: 'Hello!' })} />
+
+<button on:click={() => dispatch('message', { text: 'Hello!' })}>Say Hi!</button>
 <button on:click>Press me</button>
-// App.svelte
+
+<!-- App.svelte -->
 <script>
-import Widget from '.Widget.svelte'
+import Widget from './Widget.svelte'
 </script>
 <Widget
   on:click={() => alert('I was clicked')}
-  on:message={e => alert(e.detail.text)}>
+  on:message={e => alert(e.detail.text)} />
 `,
   },
   {
     title: 'Rendering List',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/db8ac032184b455bbeed903ba042937c',
     content: `<ul>
   {#each items as item}
   <li>{item.name} x {item.qty}</li>

--- a/src/pages/CheatSheet.svelte
+++ b/src/pages/CheatSheet.svelte
@@ -15,9 +15,8 @@
 
 <section class="container">
   {#each cheatSheet as item}
-    <Card title={$_(item.title)}>
-        <HighlightSvelte
-          code={item.content.replace(/::/g, '//')} />
+    <Card title={$_(item.title)} repl={item.repl}>
+      <HighlightSvelte code={item.content.replace(/::/g, '//')} />
     </Card>
   {/each}
 </section>


### PR DESCRIPTION
- Modificado o layout dos 3 circulos, deixaram de ser drop-shadow e são elementos individuais
- O primeiro circulo passa a ser um link para o REPL
- A estrutura de dados do cheatsheet ganhou um campo repl, para receber o link do REPL de cada card
- O conteúdo de alguns exemplos foi corrigido
- O component Card ganha uma prop "repl"