### PR TITLE
Implementar link para REPL nos cards

### DIFF
--- a/src/container/Card.svelte
+++ b/src/container/Card.svelte
@@ -1,12 +1,15 @@
 <script>
   export let title = ''
+  export let repl = ''
 </script>
 
 <section class="card">
   <header>
     <h2>{title}</h2>
     <div class="circles">
-      <span class="circle red" />
+      <a href={repl} class="circle red" title="código no REPL" target="_blank"
+        ><span /></a
+      >
       <span class="circle yellow" />
       <span class="circle green" />
     </div>

--- a/src/container/Card.svelte
+++ b/src/container/Card.svelte
@@ -5,7 +5,11 @@
 <section class="card">
   <header>
     <h2>{title}</h2>
-    <span class="circles" />
+    <div class="circles">
+      <span class="circle red" />
+      <span class="circle yellow" />
+      <span class="circle green" />
+    </div>
   </header>
   <div>
     <slot>Content</slot>
@@ -35,15 +39,30 @@
   }
 
   header > .circles {
-    display: block;
+    height: var(--m18);
+  }
+
+  .circle {
+    display: inline-block;
     width: var(--m18);
     height: var(--m18);
     border-radius: 50%;
     background-color: var(--red-color);
     border: 1px solid #fff;
-    box-shadow: 25px 0 0 0 var(--yellow-color), 50px 0 0 0 var(--green-color);
-    margin-right: 50px;
-    margin-left: 20px;
+    margin: 0 0 0 5px;
+    content: '\f30c';
+    text-decoration: none;
+  }
+  .red {
+    background-color: var(--red-color);
+  }
+
+  .yellow {
+    background-color: var(--yellow-color);
+  }
+
+  .green {
+    background-color: var(--green-color);
   }
 
   .card > div {

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -187,23 +187,24 @@ export const cheatSheet = [
   },
   {
     title: 'Forwarding Event',
-    repl: '#',
-    title: "Forwarding Event",
-    content: `// Widget.svelte
+    repl: 'https://svelte.dev/repl/f1e3b92d7a3c466bb614aa8f49cde3b1',
+    content: `<!-- Widget.svelte -->
 <script>
   import { createEventDispatcher } from "svelte";
   const dispatch = createEventDispatcher();
 </script>
-<button on:click={() => dispatch('message', { text: 'Hello!' })} />
+
+<button on:click={() => dispatch('message', { text: 'Hello!' })}>Say Hi!</button>
 <button on:click>Press me</button>
-// App.svelte
+
+<!-- App.svelte -->
 <script>
-import Widget from '.Widget.svelte'
+import Widget from './Widget.svelte'
 </script>
-<Widget 
-  on:click={() => alert('I was clicked')} 
-  on:message={e => alert(e.detail.text)}>
-`
+<Widget
+  on:click={() => alert('I was clicked')}
+  on:message={e => alert(e.detail.text)} />
+`,
   },
   {
     title: 'Rendering List',

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -47,9 +47,8 @@ export const cheatSheet = [
   },
   {
     title: 'Simple Bind',
-    repl: '#',
-    title: "Simple Bind",
-    content: `//MyLink.svelte
+    repl: 'https://svelte.dev/repl/505dfd64708844c7b28ead4834059d69',
+    content: `<!-- MyLink.svelte -->
 <script>
     export let href = ''
     export let title = ''
@@ -58,16 +57,19 @@ export const cheatSheet = [
 <a href={href} style={\`color: \${color}\`} >
   {title}
 </a>
-// Shorthand
+
+<!-- Shorthand
 <a {href} style={\`color: \${color}\`} >
   {title}
-</a>
+</a> -->
+
+<!-- App.svelte -->
 <script>
   import MyLink from "./components/MyLink";
   let link = {
     href: "http://www.mysite.com",
     title: "My Site",
-    repl: '#',
+    repl: "#",
     color: "#ff3300"
   };
 </script>

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -147,7 +147,7 @@ export const cheatSheet = [
   },
   {
     title: 'Await Template',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/22a36f1affba4334807a133d985ce6ef',
     content: `{#await promise}
   <p>waiting for the promise to resolve...</p>
 {:then value}

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -251,7 +251,7 @@ import Widget from './Widget.svelte'
   },
   {
     title: 'Multiple Slot',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/abc6ecc5953c4c77af402185a2219df4',
     content: `<!-- Widget.svelte -->
 <div>
   <slot name="header">

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -362,7 +362,7 @@ onMount(() => {
   },
   {
     title: 'Reactive Expressions',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/0f7793bf7b0745f1b356327fad4a71e1',
     content: `<script>
   let num = 0
   $: squared = num * num
@@ -371,8 +371,8 @@ onMount(() => {
 <button on:click={() => num = num + 1}>
   Increment: {num}
 </button>
-<p>{squared}</p>
-<p>{cubed}</p>
+<p>{num}<sup>2</sup> = {squared}</p>
+<p>{num}<sup>3</sup> = {cubed}</p>
 `,
   },
   {

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -287,18 +287,20 @@ import Widget from './Widget.svelte'
   },
   {
     title: 'Class Binding',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/c0c8e997fec1428ba670d4a95829d110',
     content: `<script>
    export let type = 'normal'
    export let active = true
 </script>
-<div class={active ? active : ''}  class={type}>
-...
-</div>
+
+<div class={active ? active : ''}>...</div>
+<div class={type}>...</div>
+
 <div class:active={active} class={\`otherClass \${type}\`}>
 ...
 </div>
-// Match class
+
+<!-- Class Toggle -->
 <div class:active>...</div>
 `,
   },

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -159,11 +159,11 @@ export const cheatSheet = [
   },
   {
     title: 'Render HTML',
-    repl: '#',
-    title: "Render HTML",
-    content: `<scrit>
+    repl: 'https://svelte.dev/repl/44896bb6272d48b2a0a5909678b07cc9',
+    content: `<script>
   const myHtml = '<span><strong>My text:</strong> text</span>'
-</scrit>
+</script>
+
 {@html '<div>Content</div>'}
 {@html myHtml}
 `,

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -131,7 +131,7 @@ export const cheatSheet = [
   },
   {
     title: 'Conditional Render',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/b023c56cdf0d42819fe7ccc38ea75c41',
     content: `{#if condition}
   <p>Condition is true</p>
 {:else if otherCondition}

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -115,7 +115,7 @@ export const cheatSheet = [
   },
   {
     title: 'Use action',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/6262d071414f42e98cdeed1f3c78d93e',
     content: `<script>
   function myFunction(node) {
     // the node has been mounted in the DOM

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -326,16 +326,16 @@ onMount(() => {
   },
   {
     title: 'Animations',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/f2ba3adfe6cf49a58a38540530567354',
     content: `<script>
   import { flip } from "svelte/animate";
   import { quintOut } from "svelte/easing";
   let list = [1, 2, 3];
 </script>
 {#each list as n (n)}
-  <div animate:flip={{ 
-    delay: 250, 
-    duration: 250, 
+  <div animate:flip={{
+    delay: 250,
+    duration: 2000,
     easing: quintOut
   }}>
     {n}

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -1,6 +1,7 @@
 export const cheatSheet = [
   {
-    title: "Svelte Component",
+    title: 'Svelte Component',
+    repl: '#',
     content: `<!-- Widget.svelte -->
 <script>
   export let textValue
@@ -19,11 +20,12 @@ export const cheatSheet = [
   const title = 'App'
 </script>
 <header>{title}</header>
-<Widget textValue="I'm a svelte component" />
-`
+<Widget textValue="I'm a Svelte component" />
+`,
   },
   {
-    title: "Expressions",
+    title: 'Expressions',
+    repl: '#',
     content: `<script>
   let isShowing = true
   let cat = 'cat'
@@ -31,19 +33,20 @@ export const cheatSheet = [
   let email = 'professionalkiller@gmail.com'
 </script>
 <p>2 + 2 = {2 + 2}</p>
-   
+
 <p on:click={() => isShowing = !isShowing}>
-  {isShowing 
-    ? 'NOW YOU SEE ME 👀' 
+  {isShowing
+    ? 'NOW YOU SEE ME 👀'
     : 'NOW YOU DON\`T SEE ME 🙈'}
 </p>
 <p>My e-mail is {email}</p>
 <p>{user.name}</p>
 <p>{cat + \`s\`}</p>
-<p>{\`name \${user.name}\`}</p>`
-
+<p>{\`name \${user.name}\`}</p>`,
   },
   {
+    title: 'Simple Bind',
+    repl: '#',
     title: "Simple Bind",
     content: `//MyLink.svelte
 <script>
@@ -63,14 +66,16 @@ export const cheatSheet = [
   let link = {
     href: "http://www.mysite.com",
     title: "My Site",
+    repl: '#',
     color: "#ff3300"
   };
 </script>
 <MyLink {...link} />
-`
+`,
   },
   {
-    title: "Two Way Bind",
+    title: 'Two Way Bind',
+    repl: '#',
     content: `<MyInput bind:value={value} />
 // Shorthand
 <MyInput bind:value />
@@ -103,10 +108,11 @@ export const cheatSheet = [
   Click
 </button>
 <div bind:this={myDiv}/>
-`
+`,
   },
   {
     title: 'Use action',
+    repl: '#',
     content: `<script>
   function myFunction(node) {
     // the node has been mounted in the DOM
@@ -118,10 +124,11 @@ export const cheatSheet = [
   }
 </script>
 <div use:myFunction></div>
-    `
+    `,
   },
   {
-    title: "Conditional Render",
+    title: 'Conditional Render',
+    repl: '#',
     content: `{#if condition}
   <p>Condition is true</p>
 {:else if otherCondition}
@@ -133,10 +140,11 @@ export const cheatSheet = [
 {#key value}
 	<div transition:fade>{value}</div>
 {/key}
-`
+`,
   },
   {
-    title: "Await Template",
+    title: 'Await Template',
+    repl: '#',
     content: `{#await promise}
   <p>waiting for the promise to resolve...</p>
 {:then value}
@@ -144,21 +152,22 @@ export const cheatSheet = [
 {:catch error}
   <p>Something went wrong: {error.message}</p>
 {/await}
-`
-
+`,
   },
   {
+    title: 'Render HTML',
+    repl: '#',
     title: "Render HTML",
     content: `<scrit>
   const myHtml = '<span><strong>My text:</strong> text</span>'
 </scrit>
 {@html '<div>Content</div>'}
 {@html myHtml}
-`
-
+`,
   },
   {
-    title: "Handle Events",
+    title: 'Handle Events',
+    repl: '#',
     content: `<button on:click={handleClick}>
   Press me
 </button>
@@ -171,9 +180,11 @@ export const cheatSheet = [
 <button on:submit|preventDefault={handleClick}>
   Press me
 </button>
-`
+`,
   },
   {
+    title: 'Forwarding Event',
+    repl: '#',
     title: "Forwarding Event",
     content: `// Widget.svelte
 <script>
@@ -192,9 +203,9 @@ import Widget from '.Widget.svelte'
 `
   },
   {
-    title: "Rendering List",
-    content:
-      `<ul>
+    title: 'Rendering List',
+    repl: '#',
+    content: `<ul>
   {#each items as item}
   <li>{item.name} x {item.qty}</li>
   {:else}
@@ -213,10 +224,11 @@ import Widget from '.Widget.svelte'
     {index + 1}: {item.name} x {item.qty}
   </li>
 {/each}
-`
-
+`,
   },
   {
+    title: 'Using Slot',
+    repl: '#',
     title: "Using Slot",
     content:
       `<!-- Widget.svelte -->
@@ -228,13 +240,12 @@ import Widget from '.Widget.svelte'
 <Widget>
   <p>I   changed the default content</p>
 </Widget>
-`
-
+`,
   },
   {
-    title: "Multiple Slot",
-    content:
-      `<!-- Widget.svelte -->
+    title: 'Multiple Slot',
+    repl: '#',
+    content: `<!-- Widget.svelte -->
 <div>
   <slot name="header">
     No header was provided
@@ -265,11 +276,11 @@ import Widget from '.Widget.svelte'
     {item.text}
   </div>
 </FancyList>
-`
-
+`,
   },
   {
-    title: "Class Binding",
+    title: 'Class Binding',
+    repl: '#',
     content: `<script>
    export let type = 'normal'
    export let active = true
@@ -282,13 +293,12 @@ import Widget from '.Widget.svelte'
 </div>
 // Match class
 <div class:active>...</div>
-`
-
+`,
   },
   {
-    title: "Lifecycle",
-    content:
-      `
+    title: 'Lifecycle',
+    repl: '#',
+    content: `
 <script>
 import onMount from 'svelte'
 onMount(() => {
@@ -302,13 +312,12 @@ onMount(() => {
   beforeUpdate(() => {}),
   afterUpdate(() => {}),
   onDestroy(() => {})
-]`
-
+]`,
   },
   {
-    title: "Animations",
-    content:
-      `<script>
+    title: 'Animations',
+    repl: '#',
+    content: `<script>
   import { flip } from "svelte/animate";
   import { quintOut } from "svelte/easing";
   let list = [1, 2, 3];
@@ -322,12 +331,12 @@ onMount(() => {
     {n}
   </div>
 {/each}
-`
+`,
   },
   {
-    title: "Transitions",
-    content:
-`<script>
+    title: 'Transitions',
+    repl: '#',
+    content: `<script>
   import { fade } from "svelte/transition";
   export let condition;
 </script>
@@ -338,12 +347,12 @@ onMount(() => {
 {/if}
 // Other transitions
 [Blur, Scale, Fly, Draw, Slide]
-`
+`,
   },
   {
-    title: "Reactive Expressions",
-    content:
-`<script>
+    title: 'Reactive Expressions',
+    repl: '#',
+    content: `<script>
   let num = 0
   $: squared = num * num
   $: cubed = squared * num
@@ -353,12 +362,12 @@ onMount(() => {
 </button>
 <p>{squared}</p>
 <p>{cubed}</p>
-`
+`,
   },
   {
-    title: "Reactive Statement",
-    content:
-`<script>
+    title: 'Reactive Statement',
+    repl: '#',
+    content: `<script>
   $: if (count >= 10) {
     alert('count is dangerously high!')
     count = 9
@@ -387,6 +396,6 @@ onMount(() => {
     bar = await Promise.resolve(foo%2)
   })()
 </script>
-`
+`,
   },
 ]

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -232,17 +232,20 @@ import Widget from './Widget.svelte'
   },
   {
     title: 'Using Slot',
-    repl: '#',
-    title: "Using Slot",
-    content:
-      `<!-- Widget.svelte -->
+    repl: 'https://svelte.dev/repl/4844ee8feb794ed4bde10508cdb177cf?version=3',
+    content: `<!-- Widget.svelte -->
 <div>
   <slot>Default content</slot>
 </div>
+
 <!-- App.svelte -->
+<script>
+	import Widget from "./Widget.svelte"
+</script>
+
 <Widget />
 <Widget>
-  <p>I   changed the default content</p>
+  <p>I changed the default content</p>
 </Widget>
 `,
   },

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -208,7 +208,7 @@ import Widget from './Widget.svelte'
   },
   {
     title: 'Rendering List',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/db8ac032184b455bbeed903ba042937c',
     content: `<ul>
   {#each items as item}
   <li>{item.name} x {item.qty}</li>

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -26,7 +26,7 @@ export const cheatSheet = [
   },
   {
     title: 'Expressions',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/27bd55a7357046f2911923069dee9d86',
     content: `<script>
   let isShowing = true
   let cat = 'cat'

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -78,7 +78,7 @@ export const cheatSheet = [
   },
   {
     title: 'Two Way Bind',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/63c1cc2e6ab24d33ae531d6acdabc14e',
     content: `<MyInput bind:value={value} />
 // Shorthand
 <MyInput bind:value />
@@ -87,21 +87,21 @@ export const cheatSheet = [
   <option value="Beans">Beans</option>
   <option value="Cheese">Cheese</option>
 </select>
-<input 
-  type="radio" 
-  bind:group={tortilla} 
+<input
+  type="radio"
+  bind:group={tortilla}
   value="Plain" />
 <input
-  type="radio" 
-  bind:group={tortilla} 
+  type="radio"
+  bind:group={tortilla}
   value="Whole wheat" />
-<input 
-  type="checkbox" 
-  bind:group={fillings} 
+<input
+  type="checkbox"
+  bind:group={fillings}
   value="Rice" />
-<input 
-  type="checkbox" 
-  bind:group={fillings} 
+<input
+  type="checkbox"
+  bind:group={fillings}
   value="Beans" />
 // Element Binding
 <script>

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -377,7 +377,7 @@ onMount(() => {
   },
   {
     title: 'Reactive Statement',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/b959727e045e4eb7b70c7f16e425fed5',
     content: `<script>
   $: if (count >= 10) {
     alert('count is dangerously high!')
@@ -404,7 +404,7 @@ onMount(() => {
     baz++
   }
   $: (async () => { // and even this
-    bar = await Promise.resolve(foo%2)
+    bar = await Promise.resolve(foo % 2)
   })()
 </script>
 `,

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -170,7 +170,7 @@ export const cheatSheet = [
   },
   {
     title: 'Handle Events',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/10cfb455b7b84514b35913aabee8b5c3',
     content: `<button on:click={handleClick}>
   Press me
 </button>

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -1,7 +1,7 @@
 export const cheatSheet = [
   {
     title: 'Svelte Component',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/6a5416148c4b410b8ee0325eef54b107',
     content: `<!-- Widget.svelte -->
 <script>
   export let textValue
@@ -14,6 +14,7 @@ export const cheatSheet = [
   color: blue;
 }
 </style>
+
 <!-- App.svelte -->
 <script>
   import Widget from './Widget.svelte'

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -345,19 +345,20 @@ onMount(() => {
   },
   {
     title: 'Transitions',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/6e505d732f1e48abbd7d3c4ba4cfc34c',
     content: `<script>
   import { fade } from "svelte/transition";
-  export let condition;
+  let condition;
 </script>
 {#if condition}
   <div transition:fade={{ delay: 250, duration: 300 }}>
     fades in  and out
   </div>
 {/if}
-// Other transitions
+<-- Other transitions
+
 [Blur, Scale, Fly, Draw, Slide]
-`,
+-->`,
   },
   {
     title: 'Reactive Expressions',

--- a/src/data/cheat-sheet.js
+++ b/src/data/cheat-sheet.js
@@ -306,22 +306,23 @@ import Widget from './Widget.svelte'
   },
   {
     title: 'Lifecycle',
-    repl: '#',
+    repl: 'https://svelte.dev/repl/ca959a7e552a4b35aa678dbe9a2d2b48',
     content: `
 <script>
-import onMount from 'svelte'
+import { onMount } from 'svelte'
 onMount(() => {
   console.log('Mounting')
-  return () => (consolo.log('going out'))
+  return () => (console.log('going out'))
 })
 </script>
-// Other lifecycle functions
-[
+<!--
+	Other lifecycle functions
+
   onMount(() => {}),
   beforeUpdate(() => {}),
   afterUpdate(() => {}),
   onDestroy(() => {})
-]`,
+-->`,
   },
   {
     title: 'Animations',

--- a/src/pages/CheatSheet.svelte
+++ b/src/pages/CheatSheet.svelte
@@ -15,9 +15,8 @@
 
 <section class="container">
   {#each cheatSheet as item}
-    <Card title={$_(item.title)}>
-        <HighlightSvelte
-          code={item.content.replace(/::/g, '//')} />
+    <Card title={$_(item.title)} repl={item.repl}>
+      <HighlightSvelte code={item.content.replace(/::/g, '//')} />
     </Card>
   {/each}
 </section>


### PR DESCRIPTION
- Modificado o comportamento dos botões (circulos) nos Cards, para que seja possível atrelar comportamento (link para REPL, link para documentação, copiar código para clipboard, ...)
- Alterado os componentes e a origem dos dados para acomodar um campo/prop novo com o link do REPL e mostrar no primeiro botão (círculo vermelho) do card.
- Criado REPL e ajustado alguns erros nos cards